### PR TITLE
Bone Trasnformの記録を省略可能にした

### DIFF
--- a/EasyMotionRecorder/Assets/EasyMotionRecorder/Scripts/MotionDataRecorder.cs
+++ b/EasyMotionRecorder/Assets/EasyMotionRecorder/Scripts/MotionDataRecorder.cs
@@ -47,6 +47,9 @@ namespace Entum
         [SerializeField]
         private HumanBodyBones IK_RightFootBone = HumanBodyBones.RightFoot;
 
+        [SerializeField, Tooltip("Humanoid Animationとして利用する場合はチェックを外す事で記録処理の負荷とデータサイズを減らす事ができます")]
+        private bool _recordBoneTrasnform = true;
+
         protected HumanoidPoses Poses;
         protected float RecordedTime;
 
@@ -136,7 +139,9 @@ namespace Entum
                 serializedPose.Muscles[i] = _currentPose.muscles[i];
             }
 
-            SetHumanBoneTransformToHumanoidPoses(_animator, ref serializedPose);
+            if(_recordBoneTrasnform) {
+                SetHumanBoneTransformToHumanoidPoses(_animator, ref serializedPose);
+            }
 
             Poses.Poses.Add(serializedPose);
             FrameIndex++;


### PR DESCRIPTION
Humanoid Animationを作るのにはBone Transformの記録は不要なため、チェックボックスで記録を省略できるようにした。
- デフォルトの動作はこれまでと同じ（記録する）
- Gnenericなアニメーションを作る場合は記録が必要
- 省略するメリットで大きいのは記録したファイルサイズ。手元の環境だとおよそ1/8程度になった。
- チェックボックスは以下

![unity_inspector](https://user-images.githubusercontent.com/1302700/51803476-f908fd00-2298-11e9-863e-ba0b302600fe.jpg)
